### PR TITLE
super-linter uses .github/linters/.golangci.yml

### DIFF
--- a/.github/linters/.golangci.yml
+++ b/.github/linters/.golangci.yml
@@ -1,0 +1,1 @@
+../../.golangci.yml


### PR DESCRIPTION
try setting symlink to .golangci.yml