### PR TITLE
fix: use SetEnvKeyReplacer to be able to set

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -78,6 +78,7 @@ func NewConfig() (*Config, error) {
 
 	v.SetEnvPrefix("HCTL")
 	v.AutomaticEnv()
+	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	v.SetConfigType("yaml")
 	v.SetConfigName("hctl")
 	v.AddConfigPath(".")


### PR DESCRIPTION
YAML path like `logging.log_level` via environment variable like `HCTL_LOGGING_LOG_LEVEL`