### PR TITLE
fix: resolve linter errors

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,7 +27,7 @@ builds:
       - -X github.com/xx4h/hctl/cmd.date={{.Date}}
 
 archives:
-  - format: tar.gz
+  - formats: ['tar.gz']
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_
@@ -39,7 +39,7 @@ archives:
     # use zip for windows archives
     format_overrides:
       - goos: windows
-        format: zip
+        formats: ['zip']
 
 changelog:
   disable: true

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -69,18 +69,18 @@ func GetLocalIP() string {
 	return localAddress.IP.String()
 }
 
-func MakeRange(min, max int) []int {
-	a := make([]int, max-min+1)
+func MakeRange(mini, maxi int) []int {
+	a := make([]int, maxi-mini+1)
 	for i := range a {
-		a[i] = min + i
+		a[i] = mini + i
 	}
 	return a
 }
 
-func MakeRangeString(min, max int) []string {
-	a := make([]string, max-min+1)
+func MakeRangeString(mini, maxi int) []string {
+	a := make([]string, maxi-mini+1)
 	for i := range a {
-		a[i] = fmt.Sprint(min + i)
+		a[i] = fmt.Sprint(mini + i)
 	}
 	return a
 }


### PR DESCRIPTION
* replace deprecated goreleaser settings with their new renamed successors:
  - archives.format:str -> archives.formats:list
  - archives.format_overrides -> archives.formats_overrides
* golang 1.21 introduced built-in functions `min` and `max` rename variables to mini and maxi