### PR TITLE
Add `--transition` flag for `on` and `off` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ And here we are!
 - Support for Home Assistant
 - Turn on/off, or toggle all capable devices
 - Set brightness on all capable devices
+- Change color or color temperature on all capable devices
 - Play local and remote music files
 - Set volume on media players
 - Set temperature on capable devices

--- a/cmd/brightness.go
+++ b/cmd/brightness.go
@@ -56,7 +56,7 @@ func newBrightnessCmd(h *pkg.Hctl, out io.Writer) *cobra.Command {
 		},
 		Run: func(_ *cobra.Command, args []string) {
 			c := h.GetRest()
-			obj, state, sub, err := c.TurnLightOnCustom(args[0], args[1], "", 0)
+			obj, state, sub, err := c.TurnLightOnCustom(args[0], args[1], "", 0, 0)
 			if err != nil {
 				o.FprintError(out, err)
 			} else {

--- a/cmd/brightness.go
+++ b/cmd/brightness.go
@@ -56,7 +56,7 @@ func newBrightnessCmd(h *pkg.Hctl, out io.Writer) *cobra.Command {
 		},
 		Run: func(_ *cobra.Command, args []string) {
 			c := h.GetRest()
-			obj, state, sub, err := c.TurnLightOnCustom(args[0], args[1], "")
+			obj, state, sub, err := c.TurnLightOnCustom(args[0], args[1], "", 0)
 			if err != nil {
 				o.FprintError(out, err)
 			} else {

--- a/cmd/brightness.go
+++ b/cmd/brightness.go
@@ -56,7 +56,7 @@ func newBrightnessCmd(h *pkg.Hctl, out io.Writer) *cobra.Command {
 		},
 		Run: func(_ *cobra.Command, args []string) {
 			c := h.GetRest()
-			obj, state, sub, err := c.TurnLightOnBrightness(args[0], args[1])
+			obj, state, sub, err := c.TurnLightOnCustom(args[0], args[1], "")
 			if err != nil {
 				o.FprintError(out, err)
 			} else {

--- a/cmd/off.go
+++ b/cmd/off.go
@@ -25,9 +25,10 @@ import (
 )
 
 func newOffCmd(h *pkg.Hctl, out io.Writer) *cobra.Command {
+	var transition float64
 
 	cmd := &cobra.Command{
-		Use:   "off",
+		Use:   "off [--transition seconds]",
 		Short: "Switch or turn off a light or switch",
 		Args:  cobra.MatchAll(cobra.ExactArgs(1)),
 		ValidArgsFunction: func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -38,7 +39,13 @@ func newOffCmd(h *pkg.Hctl, out io.Writer) *cobra.Command {
 		},
 		Run: func(_ *cobra.Command, args []string) {
 			c := h.GetRest()
-			obj, state, sub, err := c.TurnOff(args[0])
+			var obj, state, sub string
+			var err error
+			if transition != 0 {
+				obj, state, sub, err = c.TurnLightOffTransition(args[0], transition)
+			} else {
+				obj, state, sub, err = c.TurnOff(args[0])
+			}
 			if err != nil {
 				o.FprintError(out, err)
 			} else {
@@ -47,6 +54,8 @@ func newOffCmd(h *pkg.Hctl, out io.Writer) *cobra.Command {
 			log.Debug().Caller().Msgf("Result: %s(%s) to %s", obj, sub, state)
 		},
 	}
+
+	cmd.PersistentFlags().Float64Var(&transition, "transition", 0, "Set transition time in seconds")
 
 	return cmd
 }

--- a/cmd/on.go
+++ b/cmd/on.go
@@ -28,9 +28,10 @@ func newOnCmd(h *pkg.Hctl, out io.Writer) *cobra.Command {
 	var brightness string
 	var color string
 	var colorTemp int
+	var transition float64
 
 	cmd := &cobra.Command{
-		Use:   "on [-b|--brightness +|-|min|max|1-99] [-c|--color R,G,B] [-t|--color_temp 153-500]",
+		Use:   "on [-b|--brightness +|-|min|max|1-99] [-c|--color R,G,B] [-t|--color_temp 153-500] [--transition seconds]",
 		Short: "Switch or turn on a light or switch",
 		Args:  cobra.MatchAll(cobra.ExactArgs(1)),
 		ValidArgsFunction: func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -55,8 +56,8 @@ func newOnCmd(h *pkg.Hctl, out io.Writer) *cobra.Command {
 			c := h.GetRest()
 			var obj, state, sub string
 			var err error
-			if brightness != "" || color != "" || colorTemp != 0 {
-				obj, state, sub, err = c.TurnLightOnCustom(args[0], brightness, color, colorTemp)
+			if brightness != "" || color != "" || colorTemp != 0 || transition != 0 {
+				obj, state, sub, err = c.TurnLightOnCustom(args[0], brightness, color, colorTemp, transition)
 			} else {
 				obj, state, sub, err = c.TurnOn(args[0])
 			}
@@ -72,6 +73,7 @@ func newOnCmd(h *pkg.Hctl, out io.Writer) *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&brightness, "brightness", "b", "", "Set brightness")
 	cmd.PersistentFlags().StringVarP(&color, "color", "c", "", "Set RGB color in format R,G,B")
 	cmd.PersistentFlags().IntVarP(&colorTemp, "color_temp", "t", 0, "Set color temperature in mireds (153-500)")
+	cmd.PersistentFlags().Float64Var(&transition, "transition", 0, "Set transition time in seconds (e.g. 1.5)")
 	err := cmd.RegisterFlagCompletionFunc("brightness", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return brightnessRange, cobra.ShellCompDirectiveKeepOrder | cobra.ShellCompDirectiveNoFileComp
 	})

--- a/cmd/on.go
+++ b/cmd/on.go
@@ -27,9 +27,10 @@ import (
 func newOnCmd(h *pkg.Hctl, out io.Writer) *cobra.Command {
 	var brightness string
 	var color string
+	var colorTemp int
 
 	cmd := &cobra.Command{
-		Use:   "on [-b|--brightness +|-|min|max|1-99] [--color R,G,B]",
+		Use:   "on [-b|--brightness +|-|min|max|1-99] [-c|--color R,G,B] [-t|--color_temp 153-500]",
 		Short: "Switch or turn on a light or switch",
 		Args:  cobra.MatchAll(cobra.ExactArgs(1)),
 		ValidArgsFunction: func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -54,8 +55,8 @@ func newOnCmd(h *pkg.Hctl, out io.Writer) *cobra.Command {
 			c := h.GetRest()
 			var obj, state, sub string
 			var err error
-			if brightness != "" || color != "" {
-				obj, state, sub, err = c.TurnLightOnCustom(args[0], brightness, color)
+			if brightness != "" || color != "" || colorTemp != 0 {
+				obj, state, sub, err = c.TurnLightOnCustom(args[0], brightness, color, colorTemp)
 			} else {
 				obj, state, sub, err = c.TurnOn(args[0])
 			}
@@ -69,7 +70,8 @@ func newOnCmd(h *pkg.Hctl, out io.Writer) *cobra.Command {
 	}
 
 	cmd.PersistentFlags().StringVarP(&brightness, "brightness", "b", "", "Set brightness")
-	cmd.PersistentFlags().StringVar(&color, "color", "", "Set RGB color in format R,G,B")
+	cmd.PersistentFlags().StringVarP(&color, "color", "c", "", "Set RGB color in format R,G,B")
+	cmd.PersistentFlags().IntVarP(&colorTemp, "color_temp", "t", 0, "Set color temperature in mireds (153-500)")
 	err := cmd.RegisterFlagCompletionFunc("brightness", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return brightnessRange, cobra.ShellCompDirectiveKeepOrder | cobra.ShellCompDirectiveNoFileComp
 	})

--- a/cmd/on.go
+++ b/cmd/on.go
@@ -26,9 +26,10 @@ import (
 
 func newOnCmd(h *pkg.Hctl, out io.Writer) *cobra.Command {
 	var brightness string
+	var color string
 
 	cmd := &cobra.Command{
-		Use:   "on [-b|--brightness +|-|min|max|1-99]",
+		Use:   "on [-b|--brightness +|-|min|max|1-99] [--color R,G,B]",
 		Short: "Switch or turn on a light or switch",
 		Args:  cobra.MatchAll(cobra.ExactArgs(1)),
 		ValidArgsFunction: func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -53,8 +54,8 @@ func newOnCmd(h *pkg.Hctl, out io.Writer) *cobra.Command {
 			c := h.GetRest()
 			var obj, state, sub string
 			var err error
-			if brightness != "" {
-				obj, state, sub, err = c.TurnLightOnBrightness(args[0], brightness)
+			if brightness != "" || color != "" {
+				obj, state, sub, err = c.TurnLightOnCustom(args[0], brightness, color)
 			} else {
 				obj, state, sub, err = c.TurnOn(args[0])
 			}
@@ -68,6 +69,7 @@ func newOnCmd(h *pkg.Hctl, out io.Writer) *cobra.Command {
 	}
 
 	cmd.PersistentFlags().StringVarP(&brightness, "brightness", "b", "", "Set brightness")
+	cmd.PersistentFlags().StringVar(&color, "color", "", "Set RGB color in format R,G,B")
 	err := cmd.RegisterFlagCompletionFunc("brightness", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return brightnessRange, cobra.ShellCompDirectiveKeepOrder | cobra.ShellCompDirectiveNoFileComp
 	})

--- a/pkg/rest/turn.go
+++ b/pkg/rest/turn.go
@@ -174,6 +174,15 @@ func (h *Hass) TurnLightOnCustom(device, brightness string, color string, colorT
 	return device, "on", domain, h.turn("on", domain, device, brightnessScaled, rgb, colorTemp, transition)
 }
 
+func (h *Hass) TurnLightOffTransition(device string, transition float64) (string, string, string, error) {
+	domain, device, err := h.entityArgHandler([]string{device}, "turn_off")
+	if err != nil {
+		return "", "", "", err
+	}
+
+	return device, "off", domain, h.turn("off", domain, device, "", nil, 0, transition)
+}
+
 func (h *Hass) TurnLightOff(obj string) (string, string, string, error) {
 	return h.TurnOff("light", obj)
 }

--- a/pkg/rest/turn.go
+++ b/pkg/rest/turn.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 )
 
-func (h *Hass) turn(state, domain, device, brightness string, rgb []int) error {
+func (h *Hass) turn(state, domain, device, brightness string, rgb []int, colorTemp int) error {
 	// if err := h.checkEntity(sub, fmt.Sprintf("turn_%s", state), obj); err != nil {
 	// 	return err
 	// }
@@ -31,6 +31,10 @@ func (h *Hass) turn(state, domain, device, brightness string, rgb []int) error {
 
 	if len(rgb) == 3 {
 		payload["rgb_color"] = rgb
+	}
+
+	if colorTemp >= 153 && colorTemp <= 500 {
+		payload["color_temp"] = colorTemp
 	}
 
 	res, err := h.api("POST", fmt.Sprintf("/services/%s/turn_%s", domain, state), payload)
@@ -50,7 +54,7 @@ func (h *Hass) TurnOff(args ...string) (string, string, string, error) {
 	if err != nil {
 		return "", "", "", err
 	}
-	return obj, "off", sub, h.turn("off", sub, obj, "", nil)
+	return obj, "off", sub, h.turn("off", sub, obj, "", nil, 0)
 }
 
 func (h *Hass) TurnOn(args ...string) (string, string, string, error) {
@@ -58,7 +62,7 @@ func (h *Hass) TurnOn(args ...string) (string, string, string, error) {
 	if err != nil {
 		return "", "", "", err
 	}
-	return obj, "on", sub, h.turn("on", sub, obj, "", nil)
+	return obj, "on", sub, h.turn("on", sub, obj, "", nil, 0)
 }
 
 func (h *Hass) brightStep(domain, device, updown string) (string, error) {
@@ -124,7 +128,7 @@ func scaleBrightness(percent string) (string, error) {
 	return fmt.Sprintf("%d", scaled), nil
 }
 
-func (h *Hass) TurnLightOnCustom(device, brightness string, color string) (string, string, string, error) {
+func (h *Hass) TurnLightOnCustom(device, brightness string, color string, colorTemp int) (string, string, string, error) {
 	domain, device, err := h.entityArgHandler([]string{device}, "turn_on")
 	switch brightness {
 	case "-":
@@ -158,7 +162,7 @@ func (h *Hass) TurnLightOnCustom(device, brightness string, color string) (strin
 		}
 	}
 
-	return device, "on", domain, h.turn("on", domain, device, brightnessScaled, rgb)
+	return device, "on", domain, h.turn("on", domain, device, brightnessScaled, rgb, colorTemp)
 }
 
 func (h *Hass) TurnLightOff(obj string) (string, string, string, error) {

--- a/pkg/rest/turn.go
+++ b/pkg/rest/turn.go
@@ -115,6 +115,15 @@ func parseRGB(color string) ([]int, error) {
 	return rgb, nil
 }
 
+func scaleBrightness(percent string) (string, error) {
+	val, err := strconv.Atoi(percent)
+	if err != nil || val < 1 || val > 99 {
+		return "", fmt.Errorf("Invalid brightness percentage: %s", percent)
+	}
+	scaled := int(float64(val) / 99.0 * 255.0)
+	return fmt.Sprintf("%d", scaled), nil
+}
+
 func (h *Hass) TurnLightOnCustom(device, brightness string, color string) (string, string, string, error) {
 	domain, device, err := h.entityArgHandler([]string{device}, "turn_on")
 	switch brightness {
@@ -141,7 +150,15 @@ func (h *Hass) TurnLightOnCustom(device, brightness string, color string) (strin
 		}
 	}
 
-	return device, "on", domain, h.turn("on", domain, device, brightness, rgb)
+	var brightnessScaled string
+	if brightness != "" {
+		brightnessScaled, err = scaleBrightness(brightness)
+		if err != nil {
+			return "", "", "", err
+		}
+	}
+
+	return device, "on", domain, h.turn("on", domain, device, brightnessScaled, rgb)
 }
 
 func (h *Hass) TurnLightOff(obj string) (string, string, string, error) {

--- a/pkg/rest/turn.go
+++ b/pkg/rest/turn.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 )
 
-func (h *Hass) turn(state, domain, device, brightness string, rgb []int, colorTemp int) error {
+func (h *Hass) turn(state, domain, device, brightness string, rgb []int, colorTemp int, transition float64) error {
 	// if err := h.checkEntity(sub, fmt.Sprintf("turn_%s", state), obj); err != nil {
 	// 	return err
 	// }
@@ -35,6 +35,10 @@ func (h *Hass) turn(state, domain, device, brightness string, rgb []int, colorTe
 
 	if colorTemp >= 153 && colorTemp <= 500 {
 		payload["color_temp"] = colorTemp
+	}
+
+	if transition > 0 {
+		payload["transition"] = transition
 	}
 
 	res, err := h.api("POST", fmt.Sprintf("/services/%s/turn_%s", domain, state), payload)
@@ -54,7 +58,7 @@ func (h *Hass) TurnOff(args ...string) (string, string, string, error) {
 	if err != nil {
 		return "", "", "", err
 	}
-	return obj, "off", sub, h.turn("off", sub, obj, "", nil, 0)
+	return obj, "off", sub, h.turn("off", sub, obj, "", nil, 0, 0)
 }
 
 func (h *Hass) TurnOn(args ...string) (string, string, string, error) {
@@ -62,7 +66,7 @@ func (h *Hass) TurnOn(args ...string) (string, string, string, error) {
 	if err != nil {
 		return "", "", "", err
 	}
-	return obj, "on", sub, h.turn("on", sub, obj, "", nil, 0)
+	return obj, "on", sub, h.turn("on", sub, obj, "", nil, 0, 0)
 }
 
 func (h *Hass) brightStep(domain, device, updown string) (string, error) {
@@ -128,7 +132,7 @@ func scaleBrightness(percent string) (string, error) {
 	return fmt.Sprintf("%d", scaled), nil
 }
 
-func (h *Hass) TurnLightOnCustom(device, brightness string, color string, colorTemp int) (string, string, string, error) {
+func (h *Hass) TurnLightOnCustom(device, brightness string, color string, colorTemp int, transition float64) (string, string, string, error) {
 	domain, device, err := h.entityArgHandler([]string{device}, "turn_on")
 
 	if color != "" && colorTemp != 0 {
@@ -167,7 +171,7 @@ func (h *Hass) TurnLightOnCustom(device, brightness string, color string, colorT
 		}
 	}
 
-	return device, "on", domain, h.turn("on", domain, device, brightnessScaled, rgb, colorTemp)
+	return device, "on", domain, h.turn("on", domain, device, brightnessScaled, rgb, colorTemp, transition)
 }
 
 func (h *Hass) TurnLightOff(obj string) (string, string, string, error) {

--- a/pkg/rest/turn.go
+++ b/pkg/rest/turn.go
@@ -130,6 +130,11 @@ func scaleBrightness(percent string) (string, error) {
 
 func (h *Hass) TurnLightOnCustom(device, brightness string, color string, colorTemp int) (string, string, string, error) {
 	domain, device, err := h.entityArgHandler([]string{device}, "turn_on")
+
+	if color != "" && colorTemp != 0 {
+		return "", "", "", fmt.Errorf("Cannot specify both RGB color and color temperature at the same time")
+	}
+
 	switch brightness {
 	case "-":
 		brightness, err = h.brightStep(domain, device, "-")


### PR DESCRIPTION
Merge this PR after https://github.com/xx4h/hctl/pull/67

This PR adds support for transitions for light entities. You can now specify `--transition` for the `on` or `off` command and it will transition this entity in seconds.

Examples:
```
# Turn on light (transition time 3 seconds)
hctl on light_bulb --transition 3

# Turn off light
hctl off light_bulb --transition 3

# Change color to red (5 second transition)
hctl on light_bulb --color 255,0,0 --transition 5
```