### PR TITLE
feat: add multi-device support for action commands

### DIFF
--- a/cmd/brightness.go
+++ b/cmd/brightness.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"fmt"
 	"io"
+	"os"
 	"slices"
 
 	"github.com/rs/zerolog/log"
@@ -36,17 +37,17 @@ func newBrightnessCmd(h *pkg.Hctl, out io.Writer) *cobra.Command {
 		Use:     "brightness [+|-|min|max|1-99]",
 		Short:   "Change brightness",
 		Aliases: []string{"b", "br", "bright"},
-		Args:    cobra.MatchAll(cobra.ExactArgs(2)),
+		Args:    cobra.MatchAll(cobra.MinimumNArgs(2)),
 		ValidArgsFunction: func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) == 0 {
 				return compListStates(toComplete, args, []string{"turn_on", "turn_off"}, []string{"brightness"}, "", h)
-			} else if len(args) == 1 {
-				return brightnessRange, cobra.ShellCompDirectiveKeepOrder | cobra.ShellCompDirectiveNoFileComp
 			}
-			return nil, cobra.ShellCompDirectiveDefault
+			// Offer both devices and brightness values for subsequent args
+			devices, directive := compListStatesMulti(toComplete, args, []string{"turn_on", "turn_off"}, []string{"brightness"}, "", h)
+			return append(devices, brightnessRange...), directive
 		},
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := validateBrightness(args[1]); err != nil {
+			if err := validateBrightness(args[len(args)-1]); err != nil {
 				return err
 			}
 			if err := cmd.Root().PersistentPreRunE(cmd, args); err != nil {
@@ -56,13 +57,22 @@ func newBrightnessCmd(h *pkg.Hctl, out io.Writer) *cobra.Command {
 		},
 		Run: func(_ *cobra.Command, args []string) {
 			c := h.GetRest()
-			obj, state, sub, err := c.TurnLightOnCustom(args[0], args[1], "", 0, 0)
-			if err != nil {
-				o.FprintError(out, err)
-			} else {
-				o.FprintSuccess(out, fmt.Sprintf("%s brightness set to %s%%", obj, args[1]))
+			value := args[len(args)-1]
+			devices := args[:len(args)-1]
+			var hasErr bool
+			for _, device := range devices {
+				obj, state, sub, err := c.TurnLightOnCustom(device, value, "", 0, 0)
+				if err != nil {
+					o.FprintErrorMsg(out, err)
+					hasErr = true
+				} else {
+					o.FprintSuccess(out, fmt.Sprintf("%s brightness set to %s%%", obj, value))
+				}
+				log.Debug().Caller().Msgf("Result: %s(%s) to %s", obj, sub, state)
 			}
-			log.Debug().Caller().Msgf("Result: %s(%s) to %s", obj, sub, state)
+			if hasErr {
+				os.Exit(1)
+			}
 		},
 	}
 

--- a/cmd/brightness_test.go
+++ b/cmd/brightness_test.go
@@ -63,6 +63,11 @@ func Test_newCmdBrightness(t *testing.T) {
 			"(?m)^.*bedroom_other brightness set to -%",
 			"",
 		},
+		"set brightness multiple": {
+			"brightness light.livingroom_other light.bedroom_other 20",
+			"(?s).*livingroom_other brightness set to 20%.*bedroom_other brightness set to 20%",
+			"",
+		},
 	}
 
 	testCmd(t, h, tests)

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -154,6 +154,21 @@ func compListStates(_ string, ignoredStates []string, serviceCaps []string, attr
 	return choices, cobra.ShellCompDirectiveNoFileComp
 }
 
+// compListStatesMulti wraps compListStates and filters out already-selected devices
+func compListStatesMulti(toComplete string, args []string, serviceCaps []string, attributes []string, state string, h *pkg.Hctl) ([]string, cobra.ShellCompDirective) {
+	choices, directive := compListStates(toComplete, nil, serviceCaps, attributes, state, h)
+	if len(args) > 0 {
+		var filtered []string
+		for _, c := range choices {
+			if !slices.Contains(args, c) {
+				filtered = append(filtered, c)
+			}
+		}
+		choices = filtered
+	}
+	return choices, directive
+}
+
 func compListConfig(_ string, _ []string, h *pkg.Hctl) ([]string, cobra.ShellCompDirective) {
 	return h.GetConfigOptionsAsPaths(), cobra.ShellCompDirectiveNoFileComp
 }

--- a/cmd/off.go
+++ b/cmd/off.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"io"
+	"os"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -30,28 +31,33 @@ func newOffCmd(h *pkg.Hctl, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "off [--transition seconds]",
 		Short: "Switch or turn off a light or switch",
-		Args:  cobra.MatchAll(cobra.ExactArgs(1)),
+		Args:  cobra.MatchAll(cobra.MinimumNArgs(1)),
 		ValidArgsFunction: func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			if len(args) != 0 {
-				return noMoreArgsComp()
-			}
-			return compListStates(toComplete, args, []string{"turn_off"}, nil, "on", h)
+			return compListStatesMulti(toComplete, args, []string{"turn_off"}, nil, "on", h)
 		},
 		Run: func(_ *cobra.Command, args []string) {
 			c := h.GetRest()
-			var obj, state, sub string
-			var err error
-			if transition != 0 {
-				obj, state, sub, err = c.TurnLightOffTransition(args[0], transition)
-			} else {
-				obj, state, sub, err = c.TurnOff(args[0])
+			hasTransition := transition != 0
+			var hasErr bool
+			for _, device := range args {
+				var obj, state, sub string
+				var err error
+				if hasTransition {
+					obj, state, sub, err = c.TurnLightOffTransition(device, transition)
+				} else {
+					obj, state, sub, err = c.TurnOff(device)
+				}
+				if err != nil {
+					o.FprintErrorMsg(out, err)
+					hasErr = true
+				} else {
+					o.FprintSuccessAction(out, obj, state)
+				}
+				log.Debug().Caller().Msgf("Result: %s(%s) to %s", obj, sub, state)
 			}
-			if err != nil {
-				o.FprintError(out, err)
-			} else {
-				o.FprintSuccessAction(out, obj, state)
+			if hasErr {
+				os.Exit(1)
 			}
-			log.Debug().Caller().Msgf("Result: %s(%s) to %s", obj, sub, state)
 		},
 	}
 

--- a/cmd/off_test.go
+++ b/cmd/off_test.go
@@ -33,6 +33,11 @@ func Test_newCmdOff(t *testing.T) {
 			"(?m)^.*bedroom_other off",
 			"",
 		},
+		"turn off multiple": {
+			"off light.bedroom_other light.bedroom_main",
+			"(?s).*bedroom_other off.*bedroom_main off",
+			"",
+		},
 	}
 
 	testCmd(t, h, tests)

--- a/cmd/on.go
+++ b/cmd/on.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"io"
+	"os"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -33,12 +34,9 @@ func newOnCmd(h *pkg.Hctl, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "on [-b|--brightness +|-|min|max|1-99] [-c|--color R,G,B] [-t|--color-temp 1000-10000] [--transition seconds]",
 		Short: "Switch or turn on a light or switch",
-		Args:  cobra.MatchAll(cobra.ExactArgs(1)),
+		Args:  cobra.MatchAll(cobra.MinimumNArgs(1)),
 		ValidArgsFunction: func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			if len(args) != 0 {
-				return noMoreArgsComp()
-			}
-			return compListStates(toComplete, args, []string{"turn_on"}, nil, "off", h)
+			return compListStatesMulti(toComplete, args, []string{"turn_on"}, nil, "off", h)
 		},
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if brightness == "" {
@@ -54,19 +52,27 @@ func newOnCmd(h *pkg.Hctl, out io.Writer) *cobra.Command {
 		},
 		Run: func(_ *cobra.Command, args []string) {
 			c := h.GetRest()
-			var obj, state, sub string
-			var err error
-			if brightness != "" || color != "" || colorTemp != 0 || transition != 0 {
-				obj, state, sub, err = c.TurnLightOnCustom(args[0], brightness, color, colorTemp, transition)
-			} else {
-				obj, state, sub, err = c.TurnOn(args[0])
+			hasCustom := brightness != "" || color != "" || colorTemp != 0 || transition != 0
+			var hasErr bool
+			for _, device := range args {
+				var obj, state, sub string
+				var err error
+				if hasCustom {
+					obj, state, sub, err = c.TurnLightOnCustom(device, brightness, color, colorTemp, transition)
+				} else {
+					obj, state, sub, err = c.TurnOn(device)
+				}
+				if err != nil {
+					o.FprintErrorMsg(out, err)
+					hasErr = true
+				} else {
+					o.FprintSuccessAction(out, obj, state)
+				}
+				log.Debug().Caller().Msgf("Result: %s(%s) to %s", obj, sub, state)
 			}
-			if err != nil {
-				o.FprintError(out, err)
-			} else {
-				o.FprintSuccessAction(out, obj, state)
+			if hasErr {
+				os.Exit(1)
 			}
-			log.Debug().Caller().Msgf("Result: %s(%s) to %s", obj, sub, state)
 		},
 	}
 

--- a/cmd/on_test.go
+++ b/cmd/on_test.go
@@ -33,6 +33,11 @@ func Test_newCmdOn(t *testing.T) {
 			"(?m)^.*bedroom_main on",
 			"",
 		},
+		"turn on multiple": {
+			"on light.bedroom_main light.bedroom_other",
+			"(?s).*bedroom_main on.*bedroom_other on",
+			"",
+		},
 	}
 
 	testCmd(t, h, tests)

--- a/cmd/temperature.go
+++ b/cmd/temperature.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"io"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -28,19 +29,30 @@ func newTemperatureCmd(h *pkg.Hctl, out io.Writer) *cobra.Command {
 		Use:     "temperature",
 		Short:   "Set the temperature of a climate entity",
 		Aliases: []string{"te", "temp"}, // codespell:ignore
-		Args:    cobra.MatchAll(cobra.ExactArgs(2)),
+		Args:    cobra.MatchAll(cobra.MinimumNArgs(2)),
 		ValidArgsFunction: func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) == 0 {
 				return compListStates(toComplete, args, []string{"set_temperature"}, nil, "", h)
 			}
-			return nil, cobra.ShellCompDirectiveDefault
+			// Offer devices for subsequent args (value is free-form, no completion needed)
+			return compListStatesMulti(toComplete, args, []string{"set_temperature"}, nil, "", h)
 		},
 		Run: func(_ *cobra.Command, args []string) {
-			obj, state, err := h.TemperatureSet(args[0], args[1])
-			if err != nil {
-				o.FprintError(out, err)
+			value := args[len(args)-1]
+			devices := args[:len(args)-1]
+			var hasErr bool
+			for _, device := range devices {
+				obj, state, err := h.TemperatureSet(device, value)
+				if err != nil {
+					o.FprintErrorMsg(out, err)
+					hasErr = true
+				} else {
+					o.FprintSuccessAction(out, obj, state)
+				}
 			}
-			o.FprintSuccessAction(out, obj, state)
+			if hasErr {
+				os.Exit(1)
+			}
 		},
 	}
 

--- a/cmd/toggle.go
+++ b/cmd/toggle.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"io"
+	"os"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -30,22 +31,26 @@ func newToggleCmd(h *pkg.Hctl, out io.Writer) *cobra.Command {
 		Use:     "toggle",
 		Short:   "Toggle on/off a light or switch",
 		Aliases: []string{"t"},
-		Args:    cobra.MatchAll(cobra.ExactArgs(1)),
+		Args:    cobra.MatchAll(cobra.MinimumNArgs(1)),
 		ValidArgsFunction: func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			if len(args) != 0 {
-				return noMoreArgsComp()
-			}
-			return compListStates(toComplete, args, []string{"toggle"}, nil, "", h)
+			return compListStatesMulti(toComplete, args, []string{"toggle"}, nil, "", h)
 		},
 		Run: func(_ *cobra.Command, args []string) {
 			c := h.GetRest()
-			obj, state, sub, err := c.Toggle(args[0])
-			if err != nil {
-				o.FprintError(out, err)
-			} else {
-				o.FprintSuccessAction(out, obj, state)
+			var hasErr bool
+			for _, device := range args {
+				obj, state, sub, err := c.Toggle(device)
+				if err != nil {
+					o.FprintErrorMsg(out, err)
+					hasErr = true
+				} else {
+					o.FprintSuccessAction(out, obj, state)
+				}
+				log.Debug().Caller().Msgf("Result: %s(%s) to %s", obj, sub, state)
 			}
-			log.Debug().Caller().Msgf("Result: %s(%s) to %s", obj, sub, state)
+			if hasErr {
+				os.Exit(1)
+			}
 		},
 	}
 

--- a/cmd/toggle_test.go
+++ b/cmd/toggle_test.go
@@ -33,6 +33,11 @@ func Test_newCmdToggle(t *testing.T) {
 			"(?m)^.*bedroom_main toggle",
 			"",
 		},
+		"toggle multiple lights": {
+			"toggle light.bedroom_main light.bedroom_other",
+			"(?s).*bedroom_main toggle.*bedroom_other toggle",
+			"",
+		},
 	}
 
 	testCmd(t, h, tests)

--- a/cmd/volume.go
+++ b/cmd/volume.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"fmt"
 	"io"
+	"os"
 	"slices"
 
 	"github.com/spf13/cobra"
@@ -33,24 +34,34 @@ func newVolumeCmd(h *pkg.Hctl, out io.Writer) *cobra.Command {
 		Use:     "volume",
 		Short:   "Set volume of e.g media player",
 		Aliases: []string{"v"},
-		Args:    cobra.MatchAll(cobra.ExactArgs(2)),
+		Args:    cobra.MatchAll(cobra.MinimumNArgs(2)),
 		ValidArgsFunction: func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) == 0 {
 				return compListStates(toComplete, args, []string{"volume_set"}, nil, "", h)
-			} else if len(args) == 1 {
-				return volRange, cobra.ShellCompDirectiveNoFileComp
 			}
-			return nil, cobra.ShellCompDirectiveDefault
+			// Offer both devices and volume values for subsequent args
+			devices, directive := compListStatesMulti(toComplete, args, []string{"volume_set"}, nil, "", h)
+			return append(devices, volRange...), directive
 		},
 		Run: func(_ *cobra.Command, args []string) {
-			if !slices.Contains(volRange, args[1]) {
+			value := args[len(args)-1]
+			devices := args[:len(args)-1]
+			if !slices.Contains(volRange, value) {
 				o.FprintError(out, fmt.Errorf("volume needs to be 1-100"))
 			}
-			obj, state, err := h.VolumeSet(args[0], args[1])
-			if err != nil {
-				o.FprintError(out, err)
+			var hasErr bool
+			for _, device := range devices {
+				obj, state, err := h.VolumeSet(device, value)
+				if err != nil {
+					o.FprintErrorMsg(out, err)
+					hasErr = true
+				} else {
+					o.FprintSuccessAction(out, obj, state)
+				}
 			}
-			o.FprintSuccessAction(out, obj, state)
+			if hasErr {
+				os.Exit(1)
+			}
 		},
 	}
 

--- a/pkg/hctltest/testdata/bedroom_main_light_turn_off_response.json
+++ b/pkg/hctltest/testdata/bedroom_main_light_turn_off_response.json
@@ -1,0 +1,21 @@
+[
+  {
+    "entity_id": "light.bedroom_main",
+    "state": "off",
+    "attributes": {
+      "supported_color_modes": ["onoff"],
+      "color_mode": null,
+      "all_on": false,
+      "friendly_name": "Bedroom Main",
+      "supported_features": 0
+    },
+    "last_changed": "2024-10-12T18:25:14.915796+00:00",
+    "last_reported": "2024-10-12T18:25:14.915796+00:00",
+    "last_updated": "2024-10-12T18:25:14.915796+00:00",
+    "context": {
+      "id": "ABDCDEFGHIJKLMNOPQRSTUVW05",
+      "parent_id": null,
+      "user_id": "someuseridhash"
+    }
+  }
+]

--- a/pkg/hctltest/testdata/bedroom_other_light_toggle_response.json
+++ b/pkg/hctltest/testdata/bedroom_other_light_toggle_response.json
@@ -1,0 +1,32 @@
+[
+  {
+    "entity_id": "light.bedroom_other",
+    "state": "on",
+    "attributes": {
+      "min_color_temp_kelvin": 1538,
+      "max_color_temp_kelvin": 7142,
+      "min_mireds": 140,
+      "max_mireds": 650,
+      "effect_list": ["colorloop"],
+      "supported_color_modes": ["color_temp", "hs", "xy"],
+      "effect": null,
+      "color_mode": "xy",
+      "brightness": 70,
+      "color_temp_kelvin": null,
+      "color_temp": null,
+      "hs_color": [345.198, 89.02],
+      "rgb_color": [255, 28, 84],
+      "xy_color": [0.6447, 0.279],
+      "friendly_name": "Bedroom Other",
+      "supported_features": 44
+    },
+    "last_changed": "2024-10-19T09:06:48.406200+00:00",
+    "last_reported": "2024-10-19T09:06:48.406200+00:00",
+    "last_updated": "2024-10-19T09:06:48.406200+00:00",
+    "context": {
+      "id": "ABDCDEFGHIJKLMNOPQRSTUVW06",
+      "parent_id": null,
+      "user_id": "someuseridhash"
+    }
+  }
+]

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -64,8 +64,12 @@ func PrintSuccessListWithHeader(header []interface{}, list [][]interface{}) {
 	fmt.Println(ListWithHeader(header, list))
 }
 
-func FprintError(out io.Writer, err error) {
+func FprintErrorMsg(out io.Writer, err error) {
 	pterm.Fprint(out, pterm.Error.Sprintln(err))
+}
+
+func FprintError(out io.Writer, err error) {
+	FprintErrorMsg(out, err)
 	os.Exit(1)
 }
 


### PR DESCRIPTION
Allow on, off, toggle, brightness, volume, and temperature commands to accept multiple devices. For device+value commands (brightness, volume, temperature), the last argument is the value and all preceding arguments are devices. Shell completions filter out already-selected devices.