### PR TITLE
feat: improve error messages (#5)

### DIFF
--- a/pkg/rest/rest.go
+++ b/pkg/rest/rest.go
@@ -102,6 +102,16 @@ func (h *Hass) api(meth string, path string, payload map[string]any) ([]byte, er
 		return nil, err
 	}
 
+	if res.StatusCode == http.StatusUnauthorized {
+		return nil, fmt.Errorf("authentication failed: invalid or expired token")
+	}
+	if res.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("API endpoint not found (404): %s", path)
+	}
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected API response code %d for %s", res.StatusCode, path)
+	}
+
 	return rData, nil
 }
 
@@ -187,7 +197,71 @@ func (h *Hass) findEntity(name string, domain string, service string) (string, s
 			return d, n, nil
 		}
 	}
-	return "", "", fmt.Errorf("no Entity %s capable of %s", name, service)
+	// Entity not found in service-filtered states. Determine why.
+	name, err = h.fuzzyResolveFromAllStates(name, domain)
+	if err != nil {
+		return "", "", err
+	}
+	return "", "", h.entityNotFoundError(name, domain, service)
+}
+
+// fuzzyResolveFromAllStates tries to resolve name against all states via fuzzy
+// matching so that error messages reference the actual entity name.
+func (h *Hass) fuzzyResolveFromAllStates(name, domain string) (string, error) {
+	if !h.Fuzz {
+		return name, nil
+	}
+	allStates, err := h.GetStates()
+	if err != nil {
+		return "", err
+	}
+	var allNames []string
+	for _, s := range allStates {
+		d, n := splitDomainAndName(s.EntityID)
+		if domain != "" && domain != d {
+			continue
+		}
+		allNames = append(allNames, n)
+	}
+	if p, ok := getFuzz(name, allNames); ok {
+		return allNames[p], nil
+	}
+	return name, nil
+}
+
+// entityNotFoundError returns a specific error describing why the entity
+// could not be found for the requested service.
+func (h *Hass) entityNotFoundError(name, domain, service string) error {
+	exists, err := h.entityExists(name, domain)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		if domain != "" {
+			return fmt.Errorf("entity %s.%s does not exist", domain, name)
+		}
+		return fmt.Errorf("entity %s does not exist", name)
+	}
+
+	if domain != "" {
+		domExists, err := h.domainExists(domain)
+		if err != nil {
+			return err
+		}
+		if !domExists {
+			return fmt.Errorf("domain %s does not exist", domain)
+		}
+
+		hasSvc, err := h.domainHasService(domain, service)
+		if err != nil {
+			return err
+		}
+		if !hasSvc {
+			return fmt.Errorf("domain %s has no service %s", domain, service)
+		}
+	}
+
+	return fmt.Errorf("entity %s exists but does not support %s", name, service)
 }
 
 func (h *Hass) entityArgHandler(args []string, service string) (string, string, error) {

--- a/pkg/rest/rest_test.go
+++ b/pkg/rest/rest_test.go
@@ -13,3 +13,170 @@
 // limitations under the License.
 
 package rest
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/xx4h/hctl/pkg/hctltest"
+)
+
+func Test_findEntity_Errors(t *testing.T) {
+	ms := hctltest.MockServer(t)
+	defer ms.Close()
+	h := &Hass{
+		APIURL: ms.URL,
+		Token:  "test_token",
+	}
+
+	tests := map[string]struct {
+		name    string
+		domain  string
+		service string
+		wantErr string
+	}{
+		"entity does not exist": {
+			name:    "nonexisting",
+			domain:  "",
+			service: "toggle",
+			wantErr: "entity nonexisting does not exist",
+		},
+		"qualified entity does not exist": {
+			name:    "nonexisting",
+			domain:  "light",
+			service: "toggle",
+			wantErr: "entity light.nonexisting does not exist",
+		},
+		"entity exists but does not support service": {
+			name:    "bedroom_main",
+			domain:  "",
+			service: "speak",
+			wantErr: "entity bedroom_main exists but does not support speak",
+		},
+		"domain has no such service": {
+			name:    "bedroom_main",
+			domain:  "light",
+			service: "speak",
+			wantErr: "domain light has no service speak",
+		},
+		"happy path - no error": {
+			name:    "bedroom_main",
+			domain:  "",
+			service: "toggle",
+			wantErr: "",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			d, n, err := h.findEntity(tt.name, tt.domain, tt.service)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+				if d != "light" || n != "bedroom_main" {
+					t.Errorf("got %s.%s, want light.bedroom_main", d, n)
+				}
+			} else {
+				if err == nil {
+					t.Errorf("expected error %q, got nil", tt.wantErr)
+				} else if err.Error() != tt.wantErr {
+					t.Errorf("got error %q, want %q", err.Error(), tt.wantErr)
+				}
+			}
+		})
+	}
+}
+
+func Test_findEntity_FuzzyErrorResolution(t *testing.T) {
+	ms := hctltest.MockServer(t)
+	defer ms.Close()
+	h := &Hass{
+		APIURL: ms.URL,
+		Token:  "test_token",
+		Fuzz:   true,
+	}
+
+	tests := map[string]struct {
+		name    string
+		domain  string
+		service string
+		wantErr string
+	}{
+		"fuzzy resolves name before reporting unsupported service": {
+			name:    "bedroom_mai",
+			domain:  "",
+			service: "speak",
+			wantErr: "entity bedroom_main exists but does not support speak",
+		},
+		"fuzzy resolves name before reporting nonexistent domain service": {
+			name:    "bedroom_mai",
+			domain:  "light",
+			service: "speak",
+			wantErr: "domain light has no service speak",
+		},
+		"fuzzy match not possible reports original name": {
+			name:    "zzzzzzzzz",
+			domain:  "",
+			service: "speak",
+			wantErr: "entity zzzzzzzzz does not exist",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, _, err := h.findEntity(tt.name, tt.domain, tt.service)
+			if err == nil {
+				t.Errorf("expected error %q, got nil", tt.wantErr)
+			} else if err.Error() != tt.wantErr {
+				t.Errorf("got error %q, want %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_api_HTTPErrors(t *testing.T) {
+	tests := map[string]struct {
+		statusCode int
+		wantErr    string
+	}{
+		"unauthorized": {
+			statusCode: http.StatusUnauthorized,
+			wantErr:    "authentication failed: invalid or expired token",
+		},
+		"not found": {
+			statusCode: http.StatusNotFound,
+			wantErr:    "API endpoint not found (404): /test",
+		},
+		"server error": {
+			statusCode: http.StatusInternalServerError,
+			wantErr:    "unexpected API response code 500 for /test",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				if _, err := w.Write([]byte(`{"message": "error"}`)); err != nil {
+					t.Errorf("Error writing data: %v", err)
+				}
+			}))
+			defer ms.Close()
+
+			h := &Hass{
+				APIURL: ms.URL,
+				Token:  "test_token",
+			}
+
+			_, err := h.api("GET", "/test", nil)
+			if err == nil {
+				t.Errorf("expected error %q, got nil", tt.wantErr)
+			} else if err.Error() != tt.wantErr {
+				t.Errorf("got error %q, want %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/rest/services.go
+++ b/pkg/rest/services.go
@@ -49,6 +49,33 @@ func (h *Hass) GetServices() ([]HassService, error) {
 	return services, nil
 }
 
+func (h *Hass) domainExists(domain string) (bool, error) {
+	services, err := h.GetServices()
+	if err != nil {
+		return false, err
+	}
+	for _, svc := range services {
+		if svc.Domain == domain {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (h *Hass) domainHasService(domain, service string) (bool, error) {
+	services, err := h.GetServices()
+	if err != nil {
+		return false, err
+	}
+	for _, svc := range services {
+		if svc.Domain == domain {
+			_, ok := svc.Services[service]
+			return ok, nil
+		}
+	}
+	return false, nil
+}
+
 func (h *Hass) GetFilteredServices(domains []string, services []string) ([]HassService, error) {
 	s, err := h.GetServices()
 	if err != nil {

--- a/pkg/rest/states.go
+++ b/pkg/rest/states.go
@@ -91,6 +91,20 @@ func (h *Hass) GetFilteredStatesMap(domains []string) (map[string][]string, erro
 	return t, nil
 }
 
+func (h *Hass) entityExists(name, domain string) (bool, error) {
+	states, err := h.GetStates()
+	if err != nil {
+		return false, err
+	}
+	for _, s := range states {
+		d, n := splitDomainAndName(s.EntityID)
+		if n == name && (domain == "" || d == domain) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func (h *Hass) GetStatesWithService(service string) ([]HassState, error) {
 	var domainsWithService []string
 	var statesWithService []HassState


### PR DESCRIPTION
Replace the generic "no Entity X capable of Y" error with specific messages distinguishing: entity not found, domain not found, domain lacks service, and entity exists but wrong domain. Also add HTTP status code checking to the API client (401, 404, other non-200).

When fuzzy matching is enabled, resolve the entity name against all states before producing error messages so that typos reference the matched entity rather than the raw input.